### PR TITLE
Enviar las fotos a la API backend

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,7 +15,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,12 +7,15 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="/usr/local/Cellar/gradle/7.3.3/libexec" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,10 +7,12 @@
         <entry key="..\:/ORT/4 Cuatrimestre/PF/SafetyDetector-Android/app/src/main/res/layout/activity_main.xml" value="0.259963768115942" />
         <entry key="..\:/ORT/4 Cuatrimestre/PF/SafetyDetector-Android/app/src/main/res/layout/activity_splash_screen.xml" value="0.259963768115942" />
         <entry key="..\:/ORT/4 Cuatrimestre/TP3/kotlin-principiantes/CameraX/app/src/main/res/layout/activity_main.xml" value="0.259963768115942" />
+        <entry key="app/src/main/res/layout/activity_home_screen.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/activity_main.xml" value="0.18645833333333334" />
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,8 +24,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
     kotlinOptions {
         jvmTarget = '1.8'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,9 @@
     <uses-feature android:name="android.hardware.camera.any" />
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!--uses-permission android:name="android.permission.RECORD_AUDIO" /-->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"
@@ -12,7 +14,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.CameraX">
+        android:theme="@style/Theme.CameraX"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".HomeScreen"
             android:exported="true">

--- a/app/src/main/java/ar/edu/ort/camerax/MainActivity.kt
+++ b/app/src/main/java/ar/edu/ort/camerax/MainActivity.kt
@@ -164,6 +164,7 @@ class MainActivity : AppCompatActivity() {
             override fun onImageSaved(output: ImageCapture.OutputFileResults) {
                 try {
                     val encodedImage = convertImageToBase64String(photoFile.absolutePath)
+                    photoFile.delete()
                     sendImage(encodedImage, photoFile.name)
                 } catch (exception : Exception) {
                     Toast.makeText(baseContext, "Hubo un error desconocido", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/ar/edu/ort/camerax/MainActivity.kt
+++ b/app/src/main/java/ar/edu/ort/camerax/MainActivity.kt
@@ -67,7 +67,7 @@ class MainActivity : AppCompatActivity() {
     private fun convertImageToBase64String(@NonNull path : String): String {
         val bitmap = BitmapFactory.decodeFile(path)
         val outputStream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream)
         return Base64.getEncoder().encodeToString(outputStream.toByteArray())
     }
 
@@ -85,6 +85,7 @@ class MainActivity : AppCompatActivity() {
                 stringBuilder.append(output)
             }
             return stringBuilder.toString()
+
         } catch (exception : Exception) {
             Log.e(TAG, "No se pudo leer la respuesta del servidor", exception)
             return ""
@@ -102,7 +103,7 @@ class MainActivity : AppCompatActivity() {
             }
             Log.d(TAG, msg)
 
-            val url = URL("http://localhost:5255/api/Images")
+            val url = URL("http://localhost:5255/api/SafetyPredictions")
             val connection = url.openConnection() as HttpURLConnection
             connection.requestMethod = "POST"
             connection.setRequestProperty("Content-Type", "application/json;charset=utf-8")
@@ -120,9 +121,15 @@ class MainActivity : AppCompatActivity() {
                 val input: ByteArray = jsonRequest.toByteArray(Charsets.UTF_8)
                 outputStream.write(input, 0, input.size)
             }
-
+            val response = getResponseBody(connection)
             if (connection.responseCode == HttpURLConnection.HTTP_OK) {
-                val msg = "Se envió la foto con éxito"
+                lateinit var msg : String
+                if(response.contains("\"isSafe\":true")) {
+                    msg = "Es seguro"
+                }
+                else{
+                    msg = "No es seguro"
+                }
                 runOnUiThread {
                     Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
                 }
@@ -134,7 +141,7 @@ class MainActivity : AppCompatActivity() {
                     Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
                 }
             }
-            Log.d(TAG, "El servidor respondió con statusCode=${connection.responseCode} y body=${getResponseBody(connection)}")
+            Log.d(TAG, "El servidor respondió con statusCode=${connection.responseCode} y body=${response}")
         }.start()
     }
 

--- a/app/src/main/java/ar/edu/ort/camerax/MainActivity.kt
+++ b/app/src/main/java/ar/edu/ort/camerax/MainActivity.kt
@@ -25,7 +25,6 @@ import java.io.File
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
-import java.nio.ByteBuffer
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.ExecutorService
@@ -65,12 +64,11 @@ class MainActivity : AppCompatActivity() {
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun convertImageToBase64String(@NonNull imageProxy: ImageProxy): String {
-        val buffer: ByteBuffer = imageProxy.planes[0].buffer
-        val bytes = ByteArray(buffer.capacity())
-        buffer.get(bytes)
-        //val bitmapImage = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, null)
-        return Base64.getEncoder().encodeToString(bytes)
+    private fun convertImageToBase64String(@NonNull path : String): String {
+        val bitmap = BitmapFactory.decodeFile(path)
+        val outputStream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+        return Base64.getEncoder().encodeToString(outputStream.toByteArray())
     }
 
     private fun getResponseBody(@NonNull connection : HttpURLConnection) : String {
@@ -94,40 +92,50 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun sendImage(@NonNull imageBase64: String, @NonNull imageName: String) {
-        val msg = "Enviando foto para analizar"
-        //Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
-        Log.d(TAG, msg)
+        Thread {
+            // Corre en otro thread porque Android no permite el uso de internet en el thread
+            // principal para no bloquear la UI
 
-        val url = URL("http://localhost:5255/api/Images")
-        val connection = url.openConnection() as HttpURLConnection
-        connection.requestMethod = "POST"
-        connection.setRequestProperty("Content-Type", "application/json;charset=utf-8")
-        connection.setRequestProperty("Accept", "application/json;charset=utf-8")
-        connection.doOutput = true
+            val msg = "Enviando foto para analizar"
+            runOnUiThread {
+                Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
+            }
+            Log.d(TAG, msg)
 
-        val jsonRequest =
-            """
+            val url = URL("http://localhost:5255/api/Images")
+            val connection = url.openConnection() as HttpURLConnection
+            connection.requestMethod = "POST"
+            connection.setRequestProperty("Content-Type", "application/json;charset=utf-8")
+            connection.setRequestProperty("Accept", "application/json;charset=utf-8")
+            connection.doOutput = true
+
+            val jsonRequest = """
                     {
                         "base64ImageString": "$imageBase64",
                         "imageName": "$imageName"
                     }
             """
 
-        connection.outputStream.use { outputStream ->
-            val input: ByteArray = jsonRequest.toByteArray(Charsets.UTF_8)
-            outputStream.write(input, 0, input.size)
-        }
+            connection.outputStream.use { outputStream ->
+                val input: ByteArray = jsonRequest.toByteArray(Charsets.UTF_8)
+                outputStream.write(input, 0, input.size)
+            }
 
-        if (connection.responseCode == HttpURLConnection.HTTP_OK) {
-            val msg = "Se envió la foto con éxito"
-            //Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
-            Log.d(TAG, msg)
-        } else {
-            val msg = "Ocurrió un error enviando la foto"
-            Log.d(TAG, msg)
-            //Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
-        }
-        Log.d(TAG, getResponseBody(connection))
+            if (connection.responseCode == HttpURLConnection.HTTP_OK) {
+                val msg = "Se envió la foto con éxito"
+                runOnUiThread {
+                    Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
+                }
+                Log.d(TAG, msg)
+            } else {
+                val msg = "Ocurrió un error enviando la foto"
+                Log.d(TAG, msg)
+                runOnUiThread {
+                    Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
+                }
+            }
+            Log.d(TAG, "El servidor respondió con statusCode=${connection.responseCode} y body=${getResponseBody(connection)}")
+        }.start()
     }
 
     private fun takePhoto() {
@@ -145,32 +153,7 @@ class MainActivity : AppCompatActivity() {
 
         // Set up image capture listener, which is triggered after photo has
         // been taken
-        val callback = object : ImageCapture.OnImageCapturedCallback() {
-            @RequiresApi(Build.VERSION_CODES.O)
-            override fun onCaptureSuccess(@NonNull image: ImageProxy) {
-                sendImage(convertImageToBase64String(image), image.imageInfo.timestamp as String)
-
-
-
-                /*val baos = ByteArrayOutputStream()
-                BitmapFactory.decodeStream(image.image)
-                val bitmap = BitmapFactory.decodeResource(resources, R.drawable.logo)
-                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, baos)
-                val imageBytes: ByteArray = baos.toByteArray()
-                */
-            }
-            override fun onError(@NonNull exception: ImageCaptureException) {
-                val msg = "No se pudo tomar la foto: ${exception.message}"
-                Log.e(TAG, msg, exception)
-                Toast.makeText(baseContext, msg, Toast.LENGTH_SHORT).show()
-            }
-        }
-        val executor = ContextCompat.getMainExecutor(this)
-        //imageCapture.takePicture(executor, callback)
-
-
-        imageCapture.takePicture(
-                outputOptions, executor, object : ImageCapture.OnImageSavedCallback {
+        val callback = object : ImageCapture.OnImageSavedCallback {
             override fun onError(exception: ImageCaptureException) {
                 val msg = "No se pudo tomar la foto: ${exception.message}"
                 Log.e(TAG, msg, exception)
@@ -180,20 +163,17 @@ class MainActivity : AppCompatActivity() {
             @RequiresApi(Build.VERSION_CODES.O)
             override fun onImageSaved(output: ImageCapture.OutputFileResults) {
                 try {
-                    val bitmap = BitmapFactory.decodeFile(photoFile.absolutePath)
-                    val outputStream = ByteArrayOutputStream()
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
-                    val encodedImage: String = Base64.getEncoder().encodeToString(outputStream.toByteArray())
-                    Thread {
-                        sendImage(encodedImage, photoFile.name)
-                    }.start()
+                    val encodedImage = convertImageToBase64String(photoFile.absolutePath)
+                    sendImage(encodedImage, photoFile.name)
                 } catch (exception : Exception) {
                     Toast.makeText(baseContext, "Hubo un error desconocido", Toast.LENGTH_SHORT).show()
                     Log.e(TAG, exception.message, exception)
                 }
 
             }
-        })
+        }
+        val executor = ContextCompat.getMainExecutor(this)
+        imageCapture.takePicture(outputOptions, executor, callback)
         
     }
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true"/>
+    <!--domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config-->
+</network-security-config>

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
+        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 22 23:43:51 ART 2021
+#Thu Jun 16 20:21:55 ART 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Para probar subir imagenes desde la app de android corriendo en un celular es necesario hacer port forwarding, que se puede hacer de la siguiente manera:

1. Abrir Chrome
2. Navegar a `chrome://inspect/#devices`
3. Marcar `Discover USB devices`
4. Cliquear en `Port forwarding` y en esa ventana marcar `Enable port forwarding` y agregar `5255 -> localhost:5255`


Adicionalmente, se debe tener levantada la API backend con una rama que el endpoint de imagenes las reciba en formato base64; este codigo aun no esta mergeado a main pero se puede probar desde la rama `imagenes-base64`. Cuando se mergee el PR https://github.com/hertzuort/safetydetector/pull/7 se va a poder probar desde main